### PR TITLE
Fix paragraph text color in light/dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -107,6 +107,10 @@
     position: relative;
     overflow-x: hidden;
   }
+
+  p {
+    @apply text-black dark:text-white;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
- set default text colors for `p` elements using Tailwind classes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684af25a60a483299b93c8d6aa8fe849