### PR TITLE
Add lexicon page with admin link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import Winners from "./pages/Winners";
 import PolitiqueConfidentialite from "./pages/PolitiqueConfidentialite";
 import ConditionsGenerales from "./pages/ConditionsGenerales";
 import ReglementDuJeu from "./pages/ReglementDuJeu";
+import Lexique from "./pages/Lexique";
 import Dashboard from "./pages/admin/Dashboard";
 import ProductsAdmin from "./pages/admin/ProductsAdmin";
 import LotteriesAdmin from "./pages/admin/LotteriesAdmin";
@@ -70,6 +71,7 @@ function AppContent() {
         <Route path="/politique-confidentialite" element={<PolitiqueConfidentialite />} />
         <Route path="/conditions-generales" element={<ConditionsGenerales />} />
         <Route path="/reglement-du-jeu" element={<ReglementDuJeu />} />
+        <Route path="/lexique" element={<Lexique />} />
         
         {/* User account route - unified */}
         <Route 

--- a/src/pages/Lexique.tsx
+++ b/src/pages/Lexique.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import Navbar from '@/components/layout/Navbar';
+import Footer from '@/components/layout/Footer';
+import { BookOpen } from 'lucide-react';
+
+const Lexique = () => {
+  const terms = [
+    {
+      term: 'WinShirt',
+      definition:
+        "Plateforme de personnalisation de t-shirts combinée à un système de loteries.",
+    },
+    {
+      term: 'Loterie',
+      definition:
+        "Tirage au sort associé à certains achats permettant de remporter des lots.",
+    },
+    {
+      term: 'Produit',
+      definition:
+        "Article vendu sur le site, souvent personnalisable selon vos envies.",
+    },
+    {
+      term: 'Design',
+      definition:
+        "Visuel pouvant être appliqué sur un t-shirt personnalisé.",
+    },
+    {
+      term: 'Mockup',
+      definition:
+        "Aperçu numérique d’un produit permettant de prévisualiser la personnalisation.",
+    },
+    {
+      term: 'DTF',
+      definition:
+        "Technique d’impression Direct To Film utilisée pour réaliser les motifs.",
+    },
+    {
+      term: 'Panier',
+      definition:
+        "Espace où sont regroupés vos articles avant le paiement.",
+    },
+    {
+      term: 'Commande',
+      definition:
+        "Ensemble des articles achetés et des informations de livraison.",
+    },
+    {
+      term: 'Compte',
+      definition:
+        "Section personnelle permettant de suivre vos commandes et loteries.",
+    },
+    {
+      term: 'Admin',
+      definition:
+        "Interface de gestion du site réservée aux utilisateurs autorisés.",
+    },
+    {
+      term: 'Supabase',
+      definition:
+        "Service backend utilisé pour la base de données et l’authentification.",
+    },
+    {
+      term: 'Stripe',
+      definition:
+        "Fournisseur de paiement sécurisé employé pour traiter les transactions.",
+    },
+    {
+      term: 'Thème',
+      definition:
+        "Paramètres permettant de personnaliser l’apparence du site.",
+    },
+  ];
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Navbar />
+      <main className="flex-grow pt-24 pb-20">
+        <div className="container mx-auto px-4">
+          <div className="max-w-4xl mx-auto">
+            <div className="text-center mb-12">
+              <h1 className="text-4xl md:text-5xl font-bold mb-6">
+                Lexique <span className="text-gradient">WinShirt</span>
+              </h1>
+              <p className="text-lg text-white/70">
+                Découvrez la définition des principaux termes de l’application.
+              </p>
+            </div>
+            <div className="space-y-4">
+              {terms.map((item, index) => (
+                <div key={index} className="glass-card p-6 rounded-xl">
+                  <h3 className="text-xl font-semibold mb-2 flex items-center gap-2">
+                    <BookOpen className="w-5 h-5 text-winshirt-purple" />
+                    {item.term}
+                  </h3>
+                  <p className="text-white/80">{item.definition}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Lexique;

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
 import GlassCard from '@/components/ui/GlassCard';
-import { ShoppingBag, Ticket, Award, ShoppingCart, Users, Image, Palette, Settings, BarChart, Truck, Share2, Wrench } from 'lucide-react';
+import { ShoppingBag, Ticket, Award, ShoppingCart, Users, Image, Palette, Settings, BarChart, Truck, Share2, Wrench, BookOpen } from 'lucide-react';
 
 const AdminDashboard = () => {
   const navigate = useNavigate();
@@ -93,6 +93,13 @@ const AdminDashboard = () => {
       icon: <Settings className="h-8 w-8 text-purple-500" />,
       route: '/admin/theme',
       color: 'from-purple-500/20 to-purple-500/5'
+    },
+    {
+      title: 'Lexique',
+      description: 'Glossaire des termes de l\'application',
+      icon: <BookOpen className="h-8 w-8 text-teal-400" />,
+      route: '/lexique',
+      color: 'from-teal-400/20 to-teal-400/5'
     }
   ];
   


### PR DESCRIPTION
## Summary
- create a **Lexique** page describing the main terms of the app
- register the page route in `App.tsx`
- link to the lexicon from the admin dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684af7f387448329a85a1db0dcd80320