### PR TITLE
Ensure HD capture uses persistent DOM

### DIFF
--- a/src/hooks/useUnifiedCapture.tsx
+++ b/src/hooks/useUnifiedCapture.tsx
@@ -92,7 +92,8 @@ export const useUnifiedCapture = () => {
       const canvas = await html2canvas(element, {
         useCORS: true,
         backgroundColor: isHD ? 'transparent' : '#ffffff',
-        scale: isHD ? 2 : 1,
+        // Générer une image haute résolution (≥3500px)
+        scale: isHD ? 5 : 1,
         width: isHD ? 800 : 400,
         height: isHD ? 1000 : 500,
         allowTaint: false,
@@ -112,6 +113,7 @@ export const useUnifiedCapture = () => {
       
       if (uploadUrl) {
         console.log(`✅ [UnifiedCapture] Upload réussi: ${filename} -> ${uploadUrl}`);
+        console.log(`🎯 [UnifiedCapture] Capture terminée pour ${elementId}`);
       } else {
         console.error(`❌ [UnifiedCapture] Échec upload pour ${filename}`);
       }


### PR DESCRIPTION
## Summary
- make html2canvas create ≥3500px captures by scaling the DOM element
- log capture completion for easier QA

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1e300ad48329a92985006c8d1d2c