### PR TITLE
Add capture URL example comment

### DIFF
--- a/src/services/unifiedCapture.service.ts
+++ b/src/services/unifiedCapture.service.ts
@@ -1,4 +1,19 @@
 
+/**
+ * Example of the URLs saved for a customized order.
+ *
+ * ```json
+ * {
+ *   "mockupRectoUrl": "https://media.winshirt.fr/mockups/recto_123.png",
+ *   "mockupVersoUrl": "https://media.winshirt.fr/mockups/verso_123.png",
+ *   "hdRectoUrl": "https://media.winshirt.fr/hd/recto_123.png",
+ *   "hdVersoUrl": "https://media.winshirt.fr/hd/verso_123.png"
+ * }
+ * ```
+ *
+ * Each order stores these URLs for both sides when customization is present.
+ */
+
 interface UnifiedCustomizationData {
   // Structure ancienne (rétrocompatibilité)
   customText?: string;


### PR DESCRIPTION
## Summary
- document capture URL storage at top of `unifiedCapture.service.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684bd215dd088329b8d0f0d2d2244e47