### PR TITLE
Fix production capture render size

### DIFF
--- a/src/components/product/CaptureElements.tsx
+++ b/src/components/product/CaptureElements.tsx
@@ -45,23 +45,21 @@ export const CaptureElements: React.FC<CaptureElementsProps> = ({
       </div>
 
       {/* Éléments de capture pour production HD sans produit */}
-      <div id="production-front-only" className="w-[800px] h-[1000px] bg-transparent">
+      <div id="production-front-only" className="w-[3500px] h-[3500px] bg-transparent">
         <UnifiedCustomizationRenderer
           customization={customization}
           side="front"
           withBackground={false}
           className="w-full h-full"
-          scale={2}
         />
       </div>
 
-      <div id="production-back-only" className="w-[800px] h-[1000px] bg-transparent">
+      <div id="production-back-only" className="w-[3500px] h-[3500px] bg-transparent">
         <UnifiedCustomizationRenderer
           customization={customization}
           side="back"
           withBackground={false}
           className="w-full h-full"
-          scale={2}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update the HD capture elements to use 3500px size
- rely on default scale for the renderer

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd20c79d4832993df379b08ac2906