### PR TITLE
Update HD capture settings

### DIFF
--- a/src/hooks/useUnifiedCapture.tsx
+++ b/src/hooks/useUnifiedCapture.tsx
@@ -89,14 +89,14 @@ export const useUnifiedCapture = () => {
       }
       console.log("[UnifiedCapture DEBUG] html2canvas va être appelé avec isHD =", isHD);
 
-      const canvas = await html2canvas(element, {
-        useCORS: true,
-        backgroundColor: isHD ? 'transparent' : '#ffffff',
-        // Générer une image haute résolution (≥3500px)
-        scale: isHD ? 5 : 1,
-        width: isHD ? 800 : 400,
-        height: isHD ? 1000 : 500,
-        allowTaint: false,
+        const canvas = await html2canvas(element, {
+          useCORS: true,
+          backgroundColor: isHD ? 'transparent' : '#ffffff',
+          // Générer une image haute résolution (≥3500px)
+          width: isHD ? 3500 : 400,
+          height: isHD ? 3500 : 500,
+          scale: 1,
+          allowTaint: false,
         foreignObjectRendering: false,
         logging: false,
         imageTimeout: 10000,


### PR DESCRIPTION
## Summary
- keep mockup capture settings
- adjust HD capture options to use 3500x3500 size at scale 1

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684bd20b590c8329bc7ce2471ec6d461