### PR TITLE
Add capture portal to keep capture elements in DOM

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
 
   <body>
     <div id="root"></div>
+    <div id="capture-root"></div>
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
     <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
     <script type="module" src="/src/main.tsx"></script>

--- a/src/components/product/CaptureElements.tsx
+++ b/src/components/product/CaptureElements.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { UnifiedCustomizationRenderer } from './UnifiedCustomizationRenderer';
 
 interface CaptureElementsProps {
@@ -21,7 +22,12 @@ export const CaptureElements: React.FC<CaptureElementsProps> = ({
     return selectedMockupColor ? selectedMockupColor.back_image_url : mockup?.svg_back_url;
   };
 
-  return (
+  const portalRoot = document.getElementById('capture-root');
+  if (!portalRoot) {
+    return null;
+  }
+
+  const content = (
     <div className="fixed -left-[9999px] -top-[9999px] pointer-events-none">
       {/* Éléments de capture pour mockup avec produit (preview basse def) */}
       <div id="preview-front-complete" className="w-[400px] h-[500px] bg-white">
@@ -64,4 +70,6 @@ export const CaptureElements: React.FC<CaptureElementsProps> = ({
       </div>
     </div>
   );
+
+  return createPortal(content, portalRoot);
 };


### PR DESCRIPTION
## Summary
- add a dedicated `capture-root` element in `index.html`
- render `CaptureElements` into that portal using `createPortal`
- keep hidden capture divs alive even when UI updates

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c015e9e0c8329953e9c52443656e2