### PR TITLE
Fix email test flow

### DIFF
--- a/src/pages/admin/EmailAdmin.tsx
+++ b/src/pages/admin/EmailAdmin.tsx
@@ -132,22 +132,25 @@ const EmailAdmin = () => {
 
     try {
       setLoading(true);
-      const success = await EmailService.testEmail(testEmail, templateType);
-      
-      if (success) {
+      const result = await EmailService.testEmail(testEmail, templateType);
+
+      if (result.success) {
         toast({
           title: "Succès",
           description: `Email de test envoyé à ${testEmail}`
         });
         await loadData(); // Recharger les logs
       } else {
-        throw new Error('Échec envoi test');
+        throw new Error(result.message || 'Échec envoi test');
       }
     } catch (error) {
       console.error('Erreur test email:', error);
       toast({
         title: "Erreur",
-        description: "Impossible d'envoyer l'email de test",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Impossible d'envoyer l'email de test",
         variant: "destructive"
       });
     } finally {

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -193,21 +193,28 @@ export class EmailService {
   }
 
   // Tester l'envoi d'un email
-  static async testEmail(recipientEmail: string, templateType: string): Promise<boolean> {
+  static async testEmail(
+    recipientEmail: string,
+    templateType: string
+  ): Promise<{ success: boolean; message?: string }> {
     try {
-      const { error } = await supabase.functions.invoke('test-email', {
+      const { data, error } = await supabase.functions.invoke('test-email', {
         body: { recipientEmail, templateType }
       });
 
       if (error) {
         console.error('Erreur test email:', error);
-        return false;
+        return { success: false, message: error.message };
       }
 
-      return true;
-    } catch (error) {
+      if (data && typeof data === 'object' && 'error' in data) {
+        return { success: false, message: (data as any).error };
+      }
+
+      return { success: true };
+    } catch (error: any) {
       console.error('Erreur lors du test:', error);
-      return false;
+      return { success: false, message: error.message };
     }
   }
 }

--- a/supabase/functions/send-lottery-reminders/index.ts
+++ b/supabase/functions/send-lottery-reminders/index.ts
@@ -109,7 +109,7 @@ serve(async (req) => {
     ).join('');
 
     // Configurer nodemailer
-    const transporter = nodemailer.createTransporter({
+    const transporter = nodemailer.createTransport({
       host: settings.smtp_host,
       port: settings.smtp_port,
       secure: settings.smtp_secure,

--- a/supabase/functions/send-order-confirmation/index.ts
+++ b/supabase/functions/send-order-confirmation/index.ts
@@ -103,7 +103,7 @@ serve(async (req) => {
     });
 
     // Configurer nodemailer
-    const transporter = nodemailer.createTransporter({
+    const transporter = nodemailer.createTransport({
       host: settings.smtp_host,
       port: settings.smtp_port,
       secure: settings.smtp_secure,

--- a/supabase/functions/send-shipping-notification/index.ts
+++ b/supabase/functions/send-shipping-notification/index.ts
@@ -95,7 +95,7 @@ serve(async (req) => {
     }
 
     // Configurer nodemailer
-    const transporter = nodemailer.createTransporter({
+    const transporter = nodemailer.createTransport({
       host: settings.smtp_host,
       port: settings.smtp_port,
       secure: settings.smtp_secure,


### PR DESCRIPTION
## Summary
- return details from `EmailService.testEmail`
- surface errors in `EmailAdmin` when testing templates
- use nodemailer `createTransport` in edge functions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c33ba4e908329be8c5dcbb93ab130