### PR TITLE
Replace localStorage usage with cookie/context

### DIFF
--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,5 +1,6 @@
 
 import { createContext, useContext, useEffect, useState } from "react";
+import { getCookie, setCookie } from "@/utils/cookies";
 
 type Theme = "dark" | "light" | "system";
 
@@ -28,7 +29,7 @@ export function ThemeProvider({
   ...props
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+    () => (getCookie(storageKey) as Theme) || defaultTheme
   );
 
   useEffect(() => {
@@ -51,7 +52,7 @@ export function ThemeProvider({
   const value = {
     theme,
     setTheme: (theme: Theme) => {
-      localStorage.setItem(storageKey, theme);
+      setCookie(storageKey, theme);
       setTheme(theme);
     },
   };

--- a/src/components/theme/theme-provider-wrapper.tsx
+++ b/src/components/theme/theme-provider-wrapper.tsx
@@ -1,5 +1,6 @@
 
 import { createContext, useContext, useEffect, useState } from "react";
+import { getCookie, setCookie } from "@/utils/cookies";
 
 type Theme = "dark" | "light" | "system";
 
@@ -28,7 +29,7 @@ export function WinShirtThemeProvider({
   ...props
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+    () => (getCookie(storageKey) as Theme) || defaultTheme
   );
 
   useEffect(() => {
@@ -51,7 +52,7 @@ export function WinShirtThemeProvider({
   const value = {
     theme,
     setTheme: (theme: Theme) => {
-      localStorage.setItem(storageKey, theme);
+      setCookie(storageKey, theme);
       setTheme(theme);
     },
   };

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -115,15 +115,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setUser(null);
       setSession(null);
       
-      // Only clear auth-related localStorage items to avoid breaking other features
-      const authKeys = ['sb-gyprtpqgeukcoxbfxtfg-auth-token'];
-      authKeys.forEach(key => {
-        try {
-          localStorage.removeItem(key);
-        } catch (e) {
-          console.warn('[Auth] Could not clear localStorage key:', key);
-        }
-      });
       
     } catch (error) {
       console.error("[Auth] Sign out error:", error);

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -5,13 +5,14 @@ import { CartContextType } from '@/types/cart.types';
 import { CartItem } from '@/types/supabase.types';
 import { toast } from '@/components/ui/use-toast';
 import { supabase } from '@/integrations/supabase/client';
-import { 
-  addToCart, 
-  getCartItems, 
-  removeFromCart, 
-  updateCartItemQuantity, 
+import {
+  addToCart,
+  getCartItems,
+  removeFromCart,
+  updateCartItemQuantity,
   clearCart as clearCartService,
-  migrateCartToUser
+  migrateCartToUser,
+  getOrCreateCartToken
 } from '@/services/cart.service';
 
 const CartContext = createContext<CartContextType | undefined>(undefined);
@@ -26,17 +27,20 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
   
   // Generate a cart token if not exists
   useEffect(() => {
-    const storedCartToken = localStorage.getItem('cart_token');
-    if (!storedCartToken) {
-      const newCartToken = uuidv4();
-      localStorage.setItem('cart_token', newCartToken);
-      setCartToken(newCartToken);
-      console.log("Created new cart token:", newCartToken);
-    } else {
-      setCartToken(storedCartToken);
-      console.log("Using existing cart token:", storedCartToken);
-    }
-  }, []);
+    const initToken = async () => {
+      if (!cartToken) {
+        const newCartToken = uuidv4();
+        try {
+          await getOrCreateCartToken(newCartToken);
+        } catch (err) {
+          console.error('Error creating cart token:', err);
+        }
+        setCartToken(newCartToken);
+        console.log('Created new cart token:', newCartToken);
+      }
+    };
+    initToken();
+  }, [cartToken]);
   
   // Check for auth state changes
   useEffect(() => {

--- a/src/services/aiImages.service.ts
+++ b/src/services/aiImages.service.ts
@@ -1,5 +1,6 @@
 
 import { supabase } from "@/integrations/supabase/client";
+import { getCookie, setCookie } from "@/utils/cookies";
 
 export interface AIImage {
   id: string;
@@ -53,10 +54,10 @@ export const uploadImageToSupabase = async (
 
 // Get session token for anonymous users
 export const getSessionToken = (): string => {
-  let token = localStorage.getItem('ai_session_token');
+  let token = getCookie('ai_session_token');
   if (!token) {
     token = `session_${Date.now()}_${Math.random().toString(36).substring(2, 15)}`;
-    localStorage.setItem('ai_session_token', token);
+    setCookie('ai_session_token', token);
   }
   return token;
 };

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,0 +1,13 @@
+export const getCookie = (name: string): string | null => {
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return match ? decodeURIComponent(match[2]) : null;
+};
+
+export const setCookie = (name: string, value: string, days = 365) => {
+  const expires = new Date(Date.now() + days * 864e5).toUTCString();
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+};
+
+export const deleteCookie = (name: string) => {
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/`;
+};


### PR DESCRIPTION
## Summary
- add small cookie helpers
- store theme selection using cookies
- persist AI session token via cookies
- create cart tokens in Supabase without localStorage
- simplify sign out cleanup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cf2ae6a38832997bcfe7dee544389