### PR TITLE
Sanitize SVG injections

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -65,6 +66,7 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
+    "dompurify": "^3.0.8",
     "uuid": "^9.0.1",
     "vaul": "^0.9.3",
     "zod": "^3.23.8"
@@ -86,6 +88,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/components/admin/AdminSVGUpload.tsx
+++ b/src/components/admin/AdminSVGUpload.tsx
@@ -9,6 +9,7 @@ import { Card } from '@/components/ui/card';
 import { SVGAnalysisResult, SVGCleanupResult, SVGAnalyzerService } from '@/services/svgAnalyzer.service';
 import { useToast } from '@/hooks/use-toast';
 import { uploadToExternalScript } from '@/services/api.service';
+import { sanitizeSvg } from '@/utils/sanitizeSvg';
 
 interface AdminSVGUploadProps {
   label: string;
@@ -364,9 +365,9 @@ export const AdminSVGUpload: React.FC<AdminSVGUploadProps> = ({
             
             <div className="flex justify-center">
               {svgPreview ? (
-                <div 
+                <div
                   className="max-w-32 max-h-32"
-                  dangerouslySetInnerHTML={{ __html: svgPreview }}
+                  dangerouslySetInnerHTML={{ __html: sanitizeSvg(svgPreview) }}
                 />
               ) : isSvg ? (
                 <div className="w-32 h-32 flex items-center justify-center border border-white/20 rounded">

--- a/src/components/product/ProductPreview.tsx
+++ b/src/components/product/ProductPreview.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Design } from '@/types/supabase.types';
 import { MockupColor } from '@/types/mockup.types';
+import { sanitizeSvg } from '@/utils/sanitizeSvg';
 
 interface ProductPreviewProps {
   // Product data
@@ -174,10 +175,12 @@ export const ProductPreview: React.FC<ProductPreviewProps> = ({
               {isSvgDesign() && getCurrentSvgContent() ? (
                 <div
                   className="w-[200px] h-[200px] flex items-center justify-center"
-                  dangerouslySetInnerHTML={{ 
-                    __html: getCurrentSvgContent().replace(
-                      /<svg([^>]*)>/i, 
-                      '<svg$1 width="100%" height="100%" viewBox="0 0 200 200" preserveAspectRatio="xMidYMid meet">'
+                  dangerouslySetInnerHTML={{
+                    __html: sanitizeSvg(
+                      getCurrentSvgContent().replace(
+                        /<svg([^>]*)>/i,
+                        '<svg$1 width="100%" height="100%" viewBox="0 0 200 200" preserveAspectRatio="xMidYMid meet">'
+                      )
                     )
                   }}
                   style={{ 

--- a/src/components/product/SVGColorEditor.tsx
+++ b/src/components/product/SVGColorEditor.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { Label } from '@/components/ui/label';
 import { Palette } from 'lucide-react';
+import { sanitizeSvg } from '@/utils/sanitizeSvg';
 
 interface SVGColorEditorProps {
   imageUrl: string;
@@ -254,15 +255,15 @@ export const SVGColorEditor: React.FC<SVGColorEditorProps> = ({
                   style={{ filter: `hue-rotate(${getHueRotationForColor(color)}deg)` }}
                 />
                 <div className="text-xs text-white/60">→</div>
-                <div 
+                <div
                   className="w-12 h-12"
-                  dangerouslySetInnerHTML={{ __html: svgContent }}
+                  dangerouslySetInnerHTML={{ __html: sanitizeSvg(svgContent) }}
                 />
               </div>
             ) : (
-              <div 
+              <div
                 className="w-12 h-12"
-                dangerouslySetInnerHTML={{ __html: svgContent }}
+                dangerouslySetInnerHTML={{ __html: sanitizeSvg(svgContent) }}
               />
             )}
           </div>

--- a/src/components/product/UnifiedCustomizationRenderer.tsx
+++ b/src/components/product/UnifiedCustomizationRenderer.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { decodeSVGBase64, isBase64SVG, processSVGContent } from '@/utils/svgDecoder';
+import { sanitizeSvg } from '@/utils/sanitizeSvg';
 
 interface CustomizationData {
   frontDesign?: {
@@ -100,7 +101,7 @@ export const UnifiedCustomizationRenderer: React.FC<UnifiedCustomizationRenderer
               transformOrigin: 'center',
               zIndex: 10
             }}
-            dangerouslySetInnerHTML={{ __html: processedSVG }}
+            dangerouslySetInnerHTML={{ __html: sanitizeSvg(processedSVG) }}
           />
         );
       }

--- a/src/components/ui/upload-image-field.tsx
+++ b/src/components/ui/upload-image-field.tsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { UploadButton } from '@/components/ui/upload-button';
 import { CheckCircle } from 'lucide-react';
+import { sanitizeSvg } from '@/utils/sanitizeSvg';
 
 interface UploadImageFieldProps {
   label: string;
@@ -87,9 +88,9 @@ export function UploadImageField({
           {isSvg ? (
             <div className="w-full max-w-32 h-32 flex items-center justify-center">
               {svgContent ? (
-                <div 
+                <div
                   className="max-w-full max-h-full"
-                  dangerouslySetInnerHTML={{ __html: svgContent }}
+                  dangerouslySetInnerHTML={{ __html: sanitizeSvg(svgContent) }}
                   style={{ maxHeight: '100px', maxWidth: '100px' }}
                 />
               ) : (

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -8,6 +8,7 @@ import { Design, Lottery, CartItem } from '@/types/supabase.types';
 import { MockupColor } from '@/types/mockup.types';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
+import { sanitizeSvg } from '@/utils/sanitizeSvg';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -1149,7 +1150,7 @@ const ProductDetail = () => {
                 marginTop: '-100px'
               }} onMouseDown={e => handleMouseDown(e)} onTouchStart={e => handleMouseDown(e)}>
                       {isSvgDesign() && getCurrentSvgContent() ? <div className="w-[200px] h-[200px] flex items-center justify-center" dangerouslySetInnerHTML={{
-                  __html: getCurrentSvgContent().replace(/<svg([^>]*)>/i, '<svg$1 width="100%" height="100%" viewBox="0 0 200 200" preserveAspectRatio="xMidYMid meet">')
+                  __html: sanitizeSvg(getCurrentSvgContent().replace(/<svg([^>]*)>/i, '<svg$1 width="100%" height="100%" viewBox="0 0 200 200" preserveAspectRatio="xMidYMid meet">'))
                 }} style={{
                   maxWidth: '200px',
                   maxHeight: '200px',

--- a/src/utils/__tests__/sanitizeSvg.test.ts
+++ b/src/utils/__tests__/sanitizeSvg.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeSvg } from '../sanitizeSvg';
+
+describe('sanitizeSvg', () => {
+  it('removes malicious script tags', () => {
+    const malicious = '<svg><script>alert("x")</script><rect /></svg>';
+    const sanitized = sanitizeSvg(malicious);
+    expect(sanitized).not.toContain('<script>');
+  });
+});
+

--- a/src/utils/sanitizeSvg.ts
+++ b/src/utils/sanitizeSvg.ts
@@ -1,0 +1,6 @@
+import DOMPurify from 'dompurify';
+
+export function sanitizeSvg(svg: string): string {
+  return DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } });
+}
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+});
+


### PR DESCRIPTION
## Summary
- sanitize uploaded SVGs with DOMPurify
- add sanitizer unit test
- ensure all SVG rendering uses sanitizer
- add vitest configuration

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf55540048329927583edd120049c