### PR TITLE
Fix theme toggle and add paragraph colors

### DIFF
--- a/src/components/layout/GlowNavigation.tsx
+++ b/src/components/layout/GlowNavigation.tsx
@@ -3,13 +3,12 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Home, Heart, User, ShoppingCart, Moon, Sun, Settings, Shirt, Clover } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { UnifiedThemeToggle } from '@/components/theme/theme-toggle-unified';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useOptimizedAuth } from '@/context/OptimizedAuthContext';
 import { useAdminCheck } from '@/hooks/useAdminCheck';
 import { useCart } from '@/context/CartContext';
-import { useWinShirtTheme } from '@/components/theme/theme-provider-wrapper';
+import { useTheme } from '@/components/theme-provider';
 import { toast } from 'sonner';
 
 interface NavItem {
@@ -30,7 +29,7 @@ export const GlowNavigation: React.FC = () => {
   const { isAuthenticated, signOut } = useOptimizedAuth();
   const { isAdmin } = useAdminCheck();
   const { itemCount } = useCart();
-  const { theme, setTheme } = useWinShirtTheme();
+  const { theme, setTheme } = useTheme();
   const [activeIndex, setActiveIndex] = useState(0);
   const markerRef = useRef<HTMLDivElement>(null);
   const navRef = useRef<HTMLUListElement>(null);

--- a/src/index.css
+++ b/src/index.css
@@ -108,6 +108,14 @@
     position: relative;
     overflow-x: hidden;
   }
+
+  p {
+    @apply text-black bg-white;
+  }
+
+  .dark p {
+    @apply text-white bg-black;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
- fix theme provider reference in `GlowNavigation`
- add basic dark/light styles for paragraphs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d05dfcec88329b595d339f633573e