### PR TITLE
Add preview_url and hd_url columns to orders

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -624,6 +624,8 @@ export type Database = {
           total_amount: number
           updated_at: string | null
           user_id: string | null
+          preview_url: string | null
+          hd_url: string | null
         }
         Insert: {
           created_at?: string | null
@@ -648,6 +650,8 @@ export type Database = {
           total_amount: number
           updated_at?: string | null
           user_id?: string | null
+          preview_url?: string | null
+          hd_url?: string | null
         }
         Update: {
           created_at?: string | null
@@ -672,6 +676,8 @@ export type Database = {
           total_amount?: number
           updated_at?: string | null
           user_id?: string | null
+          preview_url?: string | null
+          hd_url?: string | null
         }
         Relationships: [
           {

--- a/supabase/migrations/20250614071109-10770fbf-b525-4705-894e-9835caa8712f.sql
+++ b/supabase/migrations/20250614071109-10770fbf-b525-4705-894e-9835caa8712f.sql
@@ -1,0 +1,4 @@
+-- Add preview_url and hd_url columns to orders table
+ALTER TABLE public.orders
+ADD COLUMN preview_url text,
+ADD COLUMN hd_url text;


### PR DESCRIPTION
## Summary
- add migration to include `preview_url` and `hd_url`
- regenerate Supabase types with new fields

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d2054751c8329a608fa99babc7c7e