### PR TITLE
Add API helper for design generation

### DIFF
--- a/src/pages/admin/OrdersAdmin.tsx
+++ b/src/pages/admin/OrdersAdmin.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/select";
 import { toast } from "@/components/ui/use-toast";
 import { Skeleton } from '@/components/ui/skeleton';
+import { generateDesign } from '@/services/api.service';
 
 const OrdersAdmin = () => {
   const [orders, setOrders] = useState<ExtendedOrder[]>([]);
@@ -160,16 +161,10 @@ const OrdersAdmin = () => {
   const handleGenerateDTF = async () => {
     if (!selectedOrder) return;
     try {
-      const response = await fetch('/api/generate-design', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          orderId: selectedOrder.id,
-          json: (selectedOrder as any).json || selectedOrder.items?.[0]?.customization || {}
-        })
-      });
-
-      if (!response.ok) throw new Error('Request failed');
+      await generateDesign(
+        selectedOrder.id,
+        (selectedOrder as any).json || selectedOrder.items?.[0]?.customization || {}
+      );
 
       toast({
         title: 'Fichiers générés',

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -567,6 +567,24 @@ export const deleteSocialNetwork = async (id: string): Promise<void> => {
   }
 };
 
+export const generateDesign = async (
+  orderId: string,
+  json: any
+): Promise<any> => {
+  logger.log('[API] Generating design for order', orderId);
+  try {
+    const response = await axios.post('/api/generate-design', {
+      orderId,
+      json,
+    });
+    logger.log('[API] Design generation response:', response.data);
+    return response.data;
+  } catch (error) {
+    console.error('[API] Error generating design:', error);
+    throw error;
+  }
+};
+
 export const uploadToExternalScript = async (file: File): Promise<string> => {
   logger.log('[API] Upload vers media.winshirt.fr/upload-visuel.php:', file.name);
   


### PR DESCRIPTION
## Summary
- add `generateDesign` helper to call `/api/generate-design`
- use this helper inside `OrdersAdmin`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d237f0fc48329a5b1fc596d296544