### PR TITLE
Add converter for WinShirt JSON

### DIFF
--- a/src/utils/__tests__/winshirtToElements.test.ts
+++ b/src/utils/__tests__/winshirtToElements.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import winshirtToElements, { DesignElement } from '../winshirtToElements';
+
+describe('winshirtToElements', () => {
+  it('converts full customization JSON to front/back arrays', () => {
+    const input = {
+      frontDesign: {
+        designId: 'abc',
+        designUrl: 'https://mon-site.fr/visuel.png',
+        transform: {
+          scale: 1,
+          position: { x: 100, y: 150 },
+          rotation: 0
+        }
+      },
+      backDesign: {
+        designId: 'xyz',
+        designUrl: 'https://mon-site.fr/verso.png',
+        transform: {
+          scale: 1,
+          position: { x: 50, y: 80 },
+          rotation: 10
+        }
+      },
+      frontText: {
+        content: 'Hello',
+        font: 'Arial',
+        color: '#FF0000',
+        transform: {
+          scale: 1.5,
+          position: { x: 80, y: 200 },
+          rotation: -20
+        }
+      },
+      backText: {
+        content: 'Back here',
+        font: 'Roboto',
+        color: '#00FF00',
+        transform: {
+          scale: 1.2,
+          position: { x: 40, y: 180 },
+          rotation: 5
+        }
+      }
+    };
+
+    const result = winshirtToElements(input);
+
+    expect(result.front.length).toBe(2);
+    expect(result.back?.length).toBe(2);
+
+    const frontImage = result.front[0] as DesignElement;
+    expect(frontImage.type).toBe('image');
+    expect(frontImage.src).toBe('https://mon-site.fr/visuel.png');
+    expect(frontImage.x).toBe(100);
+    expect(frontImage.y).toBe(150);
+
+    const frontText = result.front[1] as DesignElement;
+    expect(frontText.type).toBe('text');
+    expect(frontText.text).toBe('Hello');
+    expect(frontText.font).toBe('Arial');
+  });
+});

--- a/src/utils/winshirtToElements.ts
+++ b/src/utils/winshirtToElements.ts
@@ -1,0 +1,89 @@
+export type DesignElement = {
+  type: "text" | "image";
+  zIndex: number;
+  text?: string;
+  src?: string;
+  font?: string;
+  color?: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+  rotation: number;
+};
+
+interface WinShirtTransform {
+  scale: number;
+  position: { x: number; y: number };
+  rotation: number;
+}
+
+interface WinShirtDesign {
+  designId: string;
+  designUrl: string;
+  transform: WinShirtTransform;
+}
+
+interface WinShirtText {
+  content: string;
+  font: string;
+  color: string;
+  transform: WinShirtTransform;
+}
+
+interface WinShirtJSON {
+  frontDesign?: WinShirtDesign | null;
+  backDesign?: WinShirtDesign | null;
+  frontText?: WinShirtText | null;
+  backText?: WinShirtText | null;
+}
+
+const BASE_SIZE = 200;
+
+const convertSide = (
+  design: WinShirtDesign | null | undefined,
+  text: WinShirtText | null | undefined
+): DesignElement[] => {
+  const elements: DesignElement[] = [];
+  let z = 1;
+
+  if (design) {
+    const scale = design.transform?.scale ?? 1;
+    elements.push({
+      type: "image",
+      zIndex: z++,
+      src: design.designUrl,
+      x: design.transform?.position?.x ?? 0,
+      y: design.transform?.position?.y ?? 0,
+      width: BASE_SIZE * scale,
+      height: BASE_SIZE * scale,
+      rotation: design.transform?.rotation ?? 0,
+    });
+  }
+
+  if (text) {
+    elements.push({
+      type: "text",
+      zIndex: z++,
+      text: text.content,
+      font: text.font,
+      color: text.color,
+      x: text.transform?.position?.x ?? 0,
+      y: text.transform?.position?.y ?? 0,
+      rotation: text.transform?.rotation ?? 0,
+    });
+  }
+
+  return elements;
+};
+
+export const winshirtToElements = (
+  data: WinShirtJSON
+): { front: DesignElement[]; back?: DesignElement[] } => {
+  const front = convertSide(data.frontDesign, data.frontText);
+  const back = convertSide(data.backDesign, data.backText);
+
+  return back.length > 0 ? { front, back } : { front };
+};
+
+export default winshirtToElements;


### PR DESCRIPTION
## Summary
- add `winshirtToElements` utility with `DesignElement` type
- provide unit test for converting WinShirt JSON to front/back element arrays

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d288a1c0c832990edb10b40f7f9f9