### PR TITLE
Add FTPS deployment workflow

### DIFF
--- a/.github/workflows/deploy-ftps.yml
+++ b/.github/workflows/deploy-ftps.yml
@@ -1,0 +1,23 @@
+name: Deploy WordPress plugin via FTPS
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy to FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+        with:
+          server: home408430562.1and1-data.host
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          protocol: ftps
+          port: 21
+          server-dir: /Winshirt/wp-content/plugins/winshirt/
+          local-dir: winshirt/
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy WordPress plugin via FTPS using SamKirkland/FTP-Deploy-Action

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ea1624a9c83298cb677228b2dff3d