### PR TITLE
Rename product menu label to Shop

### DIFF
--- a/src/components/layout/FluidDropNavigation.tsx
+++ b/src/components/layout/FluidDropNavigation.tsx
@@ -30,7 +30,7 @@ export const FluidDropNavigation: React.FC = () => {
   };
 
   const navItems = [
-    { label: 'Produits', path: '/products' },
+    { label: 'Shop', path: '/products' },
     { label: 'Loteries', path: '/lotteries' },
     { label: 'Compte', path: '/account' },
   ];

--- a/src/components/layout/SimpleNavigation.tsx
+++ b/src/components/layout/SimpleNavigation.tsx
@@ -49,7 +49,7 @@ export const SimpleNavigation: React.FC = () => {
 
   const navItems = [
     { label: 'Accueil', path: '/' },
-    { label: 'Produits', path: '/products' },
+    { label: 'Shop', path: '/products' },
     { label: 'Loteries', path: '/lotteries' },
     { label: 'Compte', path: '/account' },
   ];


### PR DESCRIPTION
## Summary
- rename product menu label from `Produits` to `Shop`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686019004478832985e0c61ba3fd8f1c