### PR TITLE
Fix product images not showing in mobile modal

### DIFF
--- a/src/components/product/EnhancedProductPreview.tsx
+++ b/src/components/product/EnhancedProductPreview.tsx
@@ -53,11 +53,15 @@ export const EnhancedProductPreview: React.FC<EnhancedProductPreviewProps> = ({
 
   const getProductImage = () => {
     if (selectedMockupColor) {
-      return currentViewSide === 'front' ? selectedMockupColor.front_image_url : selectedMockupColor.back_image_url;
+      return currentViewSide === 'front'
+        ? selectedMockupColor.front_image_url
+        : selectedMockupColor.back_image_url || productImageUrl;
     } else if (mockup) {
-      return currentViewSide === 'front' ? mockup.svg_front_url : mockup.svg_back_url;
+      return currentViewSide === 'front'
+        ? mockup.svg_front_url
+        : mockup.svg_back_url || productImageUrl;
     }
-    return undefined;
+    return productImageUrl;
   };
 
   // Drag handlers


### PR DESCRIPTION
## Summary
- ensure `EnhancedProductPreview` uses product fallback images

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603199c4ac83298057a54958c67bf2