### PR TITLE
Fix background removal handlers

### DIFF
--- a/src/components/product/CompactUpload.tsx
+++ b/src/components/product/CompactUpload.tsx
@@ -7,7 +7,7 @@ import { Design } from '@/types/supabase.types';
 
 interface CompactUploadProps {
   onFileUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  onRemoveBackground: () => void;
+  onRemoveBackground: (tolerance?: number) => void;
   isRemovingBackground: boolean;
   currentDesign?: Design | null;
 }
@@ -62,7 +62,7 @@ export const CompactUpload: React.FC<CompactUploadProps> = ({
         <div className="pt-2 border-t border-white/10">
           <Button
             variant="outline"
-            onClick={onRemoveBackground}
+            onClick={() => onRemoveBackground(32)}
             disabled={isRemovingBackground}
             className="w-full border-white/30 hover:bg-purple-500/20 hover:border-purple-500/50"
           >

--- a/src/components/product/MobileToolsPanel.tsx
+++ b/src/components/product/MobileToolsPanel.tsx
@@ -49,7 +49,7 @@ interface MobileToolsPanelProps {
   // Other props
   onFileUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onAIImageGenerated: (imageUrl: string, imageName: string) => void;
-  onRemoveBackground: () => void;
+  onRemoveBackground: (tolerance?: number) => void;
   isRemovingBackground: boolean;
   
   // Panel height management

--- a/src/components/product/ModalPersonnalisation.tsx
+++ b/src/components/product/ModalPersonnalisation.tsx
@@ -616,7 +616,7 @@ export const ModalPersonnalisation: React.FC<ModalPersonnalisationProps> = ({
               onMockupColorChange={onMockupColorChange}
               onFileUpload={onFileUpload}
               onAIImageGenerated={onAIImageGenerated}
-              onRemoveBackground={onRemoveBackground}
+                onRemoveBackground={handleManualRemoveBackground}
               isRemovingBackground={isRemovingBackground}
               panelHeight={400}
             />

--- a/src/components/product/UploadDesign.tsx
+++ b/src/components/product/UploadDesign.tsx
@@ -9,7 +9,7 @@ import { Design } from '@/types/supabase.types';
 
 interface UploadDesignProps {
   onFileUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  onRemoveBackground: () => void;
+  onRemoveBackground: (tolerance?: number) => void;
   isRemovingBackground: boolean;
   currentDesign: Design | null;
 }
@@ -63,7 +63,7 @@ export const UploadDesign: React.FC<UploadDesignProps> = ({
             <Button
               variant="outline"
               size="sm"
-              onClick={onRemoveBackground}
+              onClick={() => onRemoveBackground(32)}
               disabled={isRemovingBackground}
               className="flex items-center gap-2"
             >


### PR DESCRIPTION
## Summary
- update `onRemoveBackground` props to accept an optional tolerance
- use wrapper functions for background removal buttons

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665e93049c832999f8281ed1b7e6bc