### PR TITLE
fix: display selected designs and simplify layers panel

### DIFF
--- a/src/components/product/ModalPersonnalisation.tsx
+++ b/src/components/product/ModalPersonnalisation.tsx
@@ -43,7 +43,7 @@ interface ModalPersonnalisationProps {
   // Design states
   selectedDesignFront: Design | null;
   selectedDesignBack: Design | null;
-  onSelectDesign: (design: Design) => void;
+  onSelectDesign: (design: Design | null) => void;
   onFileUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onAIImageGenerated: (imageUrl: string, imageName: string) => void;
   setSelectedDesignFront: (design: Design | null) => void;
@@ -340,12 +340,10 @@ export const ModalPersonnalisation: React.FC<ModalPersonnalisationProps> = ({
     textTransformFront, textTransformBack
   ]);
 
-  const handleDesignSelection = (design: Design) => {
+  const handleDesignSelection = (design: Design | null) => {
     onSelectDesign(design);
-    
-    // Check if it's an SVG and handle content appropriately
-    if (design.image_url?.toLowerCase().includes('.svg') || design.image_url?.includes('data:image/svg')) {
-      // Only fetch if it's a remote SVG URL, not a blob URL
+
+    if (design?.image_url?.toLowerCase().includes('.svg') || design?.image_url?.includes('data:image/svg')) {
       if (design.image_url.startsWith('http') && !design.image_url.startsWith('blob:')) {
         fetch(design.image_url)
           .then(response => response.text())
@@ -355,13 +353,13 @@ export const ModalPersonnalisation: React.FC<ModalPersonnalisationProps> = ({
           })
           .catch(error => {
             console.error('Error loading SVG content:', error);
-            // Fallback: try to use the URL directly
-            onSvgContentChange(`<svg viewBox="0 0 200 200"><image href="${design.image_url}" width="200" height="200"/></svg>`);
+            onSvgContentChange(`\x3csvg viewBox="0 0 200 200"\x3e<image href="${design.image_url}" width="200" height="200"/>\x3c/svg\x3e`);
           });
       } else {
-        // For blob URLs or data URLs, we assume the content is already processed
         console.log('SVG blob URL detected, skipping fetch');
       }
+    } else {
+      onSvgContentChange('');
     }
 
     closeDrawer();

--- a/src/components/product/UnifiedEditingControls.tsx
+++ b/src/components/product/UnifiedEditingControls.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
-import { RotateCw, Eraser, Sparkles, Eye, FileImage, Type, Settings } from 'lucide-react';
+import { RotateCw, Eraser, Sparkles, FileImage, Type, Settings } from 'lucide-react';
 import { Design } from '@/types/supabase.types';
 
 interface UnifiedEditingControlsProps {
@@ -66,16 +66,9 @@ export const UnifiedEditingControls: React.FC<UnifiedEditingControlsProps> = ({
     onRemoveBackground(tolerance);
   };
 
-  // Toujours afficher si au moins un élément est présent
+  // Hide the editing panel when nothing is selected
   if (!selectedDesign && !hasText) {
-    return (
-      <Card className="bg-white/5 border-white/10 p-4">
-        <div className="text-center text-white/50 text-sm">
-          <Eye className="h-6 w-6 mx-auto mb-2 opacity-50" />
-          Sélectionnez un design ou ajoutez du texte pour voir les options d'édition
-        </div>
-      </Card>
-    );
+    return null;
   }
 
   return (

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -285,7 +285,7 @@ const ProductDetail = () => {
   }, [isDragging, dragTarget, dragStart, initialPosition]);
 
   // Design selection handler
-  const handleSelectDesign = (design: Design) => {
+  const handleSelectDesign = (design: Design | null) => {
     if (currentViewSide === 'front') {
       setSelectedDesignFront(design);
     } else {


### PR DESCRIPTION
## Summary
- clear SVG data and allow deselection when choosing designs
- hide layers panel when no design or text is selected
- handle design selection reset in product detail page

## Testing
- `npm install --no-optional` *(fails: ENETUNREACH downloading onnxruntime-node)*

------
https://chatgpt.com/codex/tasks/task_e_6892eff335d48329996839199eadb4c6