### PR TITLE
chore: bump module version to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite_react_shadcn_ts",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite_react_shadcn_ts",
-      "version": "0.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@huggingface/transformers": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite_react_shadcn_ts",
   "private": true,
-  "version": "0.0.0",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- bump module version to 2.0.0

## Testing
- `npm ci` (fails: connect ENETUNREACH 140.82.114.3:443)
- `npm test` (fails: sh: 1: vitest: not found)
- `npm run lint` (fails: sh: 1: eslint: not found)

------
https://chatgpt.com/codex/tasks/task_e_6893021187b883299093aec987d6dac5