### PR TITLE
Enable design creation and tidy admin menu

### DIFF
--- a/src/components/layout/GlassNavigation.tsx
+++ b/src/components/layout/GlassNavigation.tsx
@@ -84,10 +84,18 @@ export const GlassNavigation: React.FC = () => {
                 </Link>
                 {isAuthenticated && isAdmin && (
                   <>
-                    <Link to="/admin" className="block text-white/70 hover:text-white px-3 py-2 rounded-md" onClick={() => setIsMenuOpen(false)}>
-                      Admin
+                    <Link
+                      to="/admin/designs"
+                      className="block text-white/70 hover:text-white px-3 py-2 rounded-md"
+                      onClick={() => setIsMenuOpen(false)}
+                    >
+                      Visuels
                     </Link>
-                    <Link to="/admin/users" className="block text-white/70 hover:text-white px-3 py-2 rounded-md" onClick={() => setIsMenuOpen(false)}>
+                    <Link
+                      to="/admin/users"
+                      className="block text-white/70 hover:text-white px-3 py-2 rounded-md"
+                      onClick={() => setIsMenuOpen(false)}
+                    >
                       Utilisateurs
                     </Link>
                   </>
@@ -198,7 +206,7 @@ export const GlassNavigation: React.FC = () => {
                       {isAdmin && (
                         <>
                           <DropdownMenuItem className="hover:bg-white/5">
-                            <Link to="/admin" className="flex w-full">Administration</Link>
+                            <Link to="/admin/designs" className="flex w-full">Visuels</Link>
                           </DropdownMenuItem>
                           <DropdownMenuItem className="hover:bg-white/5">
                             <Link to="/admin/users" className="flex w-full">Utilisateurs</Link>

--- a/src/pages/admin/DesignsAdmin.tsx
+++ b/src/pages/admin/DesignsAdmin.tsx
@@ -4,7 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 import Navbar from '@/components/layout/Navbar';
 import Footer from '@/components/layout/Footer';
 import {
-  fetchAllDesigns as fetchDesigns, createDesign, updateDesign, deleteDesign
+  fetchAllDesignsAdmin as fetchDesigns, createDesign, updateDesign, deleteDesign
 } from '@/services/api.service';
 import { Design } from '@/types/supabase.types';
 import { Button } from '@/components/ui/button';

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -135,6 +135,22 @@ export const fetchFeaturedLotteries = async () => {
   return [];
 };
 
+// Fetch all designs without filtering by active status for admin usage
+export const fetchAllDesignsAdmin = async (): Promise<Design[]> => {
+  try {
+    const { data, error } = await supabase
+      .from('designs')
+      .select('*')
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+    return data || [];
+  } catch (error) {
+    console.error('Error fetching admin designs:', error);
+    return [];
+  }
+};
+
 export const fetchAllDesigns = async (): Promise<Design[]> => {
   try {
     const { data, error } = await supabase
@@ -184,19 +200,37 @@ export const fetchProductsWithTickets = async () => {
   }
 };
 
-export const createDesign = async (data: any) => {
-  // Mock implementation - replace with actual API call
-  return data;
+// CRUD operations for designs
+export const createDesign = async (data: Omit<Design, 'id' | 'created_at' | 'updated_at'>): Promise<Design> => {
+  const { data: result, error } = await supabase
+    .from('designs')
+    .insert(data)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return result as Design;
 };
 
-export const updateDesign = async (id: string, data: any) => {
-  // Mock implementation - replace with actual API call
-  return data;
+export const updateDesign = async (id: string, data: Partial<Design>): Promise<Design> => {
+  const { data: result, error } = await supabase
+    .from('designs')
+    .update(data)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return result as Design;
 };
 
-export const deleteDesign = async (id: string) => {
-  // Mock implementation - replace with actual API call
-  return;
+export const deleteDesign = async (id: string): Promise<void> => {
+  const { error } = await supabase
+    .from('designs')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
 };
 
 export const fetchAllLotteries = async () => {


### PR DESCRIPTION
## Summary
- Allow admin to manage designs via Supabase CRUD helpers
- Remove duplicated admin submenu entry
- Restore single navigation link to the designs admin page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: onnxruntime-node download ENETUNREACH)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68924eca7ed083299a68db9f24f9e720