### PR TITLE
Auto-select single lottery for configured products

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 **URL**: https://lovable.dev/projects/39461029-c4f2-4c0b-9835-28dd905cefd1
 
+## Version
+
+Version 0.1.0
+
 ## How can I edit this code?
 
 There are several ways of editing your application.

--- a/src/components/product/LotterySelector.tsx
+++ b/src/components/product/LotterySelector.tsx
@@ -31,6 +31,21 @@ export const LotterySelector: React.FC<LotterySelectorProps> = ({
     setParticipantCounts(initialCounts);
   }, [lotteries]);
 
+  // Sélectionner automatiquement la seule loterie disponible le cas échéant
+  useEffect(() => {
+    if (lotteries.length === 1) {
+      const onlyLotteryTitle = lotteries[0].title;
+      if (selectedLottery !== onlyLotteryTitle) {
+        onLotteryChange(onlyLotteryTitle);
+      }
+      return;
+    }
+
+    if (lotteries.length === 0 && selectedLottery !== 'none') {
+      onLotteryChange('none');
+    }
+  }, [lotteries, selectedLottery, onLotteryChange]);
+
   if (!ticketsOffered || ticketsOffered === 0 || lotteries.length === 0) {
     return null;
   }

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -166,7 +166,9 @@ const ProductDetail = () => {
       transform: textTransformBack
     } : null;
 
-    return {
+    const lotteryName = selectedLottery !== 'none' ? selectedLottery : null;
+
+    const customization: Record<string, any> = {
       frontDesign,
       backDesign,
       frontText,
@@ -176,13 +178,20 @@ const ProductDetail = () => {
       svgContentFront: svgContentFront || null,
       svgContentBack: svgContentBack || null
     };
+
+    if (lotteryName) {
+      customization.lotteryName = lotteryName;
+    }
+
+    return customization;
   };
 
-  const hasCustomization = () => {
-    const customization = generateCustomization();
+  const hasCustomization = (customizationOverride?: ReturnType<typeof generateCustomization>) => {
+    const customization = customizationOverride || generateCustomization();
     return !!(customization.frontDesign || customization.backDesign ||
               customization.frontText || customization.backText ||
-              customization.svgContentFront || customization.svgContentBack);
+              customization.svgContentFront || customization.svgContentBack ||
+              customization.lotteryName);
   };
 
   useEffect(() => {
@@ -592,7 +601,8 @@ const ProductDetail = () => {
     try {
       setIsAdding(true);
       
-      const customization = hasCustomization() ? generateCustomization() : null;
+      const customizationData = generateCustomization();
+      const customization = hasCustomization(customizationData) ? customizationData : null;
       
       const cartItem: CartItem = {
         productId: product.id,


### PR DESCRIPTION
## Summary
- auto-select the only available lottery option when a product grants tickets to a single draw
- include the selected lottery name inside the customization payload so orders retain the choice
- document the initial application version in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e68c712fd48329949d0b3b1643bc77